### PR TITLE
Add USB descriptors for devices programmed through the Arduino environment

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -15,7 +15,7 @@ promicro16.bootloader.lock_bits=0x2F
 promicro16.build.mcu=atmega32u4
 promicro16.build.f_cpu=16000000L
 promicro16.build.vid=0x1B4F
-promicro16.build.pid=0x9206
+promicro16.build.pid=0x9205
 promicro16.build.core=arduino
 promicro16.build.variant=promicro
 
@@ -36,7 +36,7 @@ promicro8.bootloader.lock_bits=0x2F
 promicro8.build.mcu=atmega32u4
 promicro8.build.f_cpu=8000000L
 promicro8.build.vid=0x1B4F
-promicro8.build.pid=0x9204
+promicro8.build.pid=0x9203
 promicro8.build.core=arduino
 promicro8.build.variant=promicro
 
@@ -57,7 +57,7 @@ LilyPadUSB.bootloader.lock_bits=0x2F
 LilyPadUSB.build.mcu=atmega32u4
 LilyPadUSB.build.f_cpu=8000000L
 LilyPadUSB.build.vid=0x1B4F
-LilyPadUSB.build.pid=0x9208
+LilyPadUSB.build.pid=0x9207
 LilyPadUSB.build.core=arduino
 LilyPadUSB.build.variant=promicro
 
@@ -78,7 +78,7 @@ WiFlyin.bootloader.lock_bits=0x2F
 WiFlyin.build.mcu=atmega32u4
 WiFlyin.build.f_cpu=16000000L
 WiFlyin.build.vid=0x1B4F
-WiFlyin.build.pid=0x920A
+WiFlyin.build.pid=0x9209
 WiFlyin.build.core=arduino
 WiFlyin.build.variant=promicro
 
@@ -141,6 +141,6 @@ minibench.bootloader.lock_bits=0x2F
 minibench.build.mcu=atmega32u4
 minibench.build.f_cpu=16000000L
 minibench.build.vid=0x1B4F
-minibench.build.pid=0x2B75
+minibench.build.pid=0x2B74
 minibench.build.core=arduino
 minibench.build.variant=promicro

--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -49,21 +49,29 @@ const u16 STRING_LANGUAGE[2] = {
 	0x0409	// English
 };
 
-const u16 STRING_IPRODUCT[17] = {
-	(3<<8) | (2+2*16),
-#if USB_PID == 0x8036	
-	'A','r','d','u','i','n','o',' ','L','e','o','n','a','r','d','o'
+const u16 STRING_IPRODUCT[15] = {
+	(3<<8) | (2+2*14),
+#if USB_PID == 0x9209
+	'W','i','F','l','y','i','n',' ',' ',' ',' ',' ',' ',' '
+#elif USB_PID == 0x9207
+	'L','i','l','y','P','a','d','U','S','B',' ',' ',' ',' '
+#elif USB_PID == 0x9205
+	'P','r','o',' ','M','i','c','r','o',' ','5','V',' ',' '
+#elif USB_PID == 0x9203
+	'P','r','o',' ','M','i','c','r','o',' ','3','.','3','V'
+#elif USB_PID == 0x2B74
+	'M','a','K','e','y',' ','M','a','K','e','y',' ',' ',' '
 #else
-	'U','S','B',' ','I','O',' ','B','o','a','r','d',' ',' ',' ',' '
+	'U','S','B',' ','I','O',' ','B','o','a','r','d',' ',' '
 #endif
 };
 
-const u16 STRING_IMANUFACTURER[12] = {
-	(3<<8) | (2+2*11),
-#if USB_VID == 0x2341
-	'A','r','d','u','i','n','o',' ','L','L','C'
+const u16 STRING_IMANUFACTURER[21] = {
+	(3<<8) | (2+2*20),
+#if USB_VID == 0x1B4F
+	'S','p','a','r','k','f','u','n',' ','E','l','e','c','t','r','o','n','i','c','s'
 #else
-	'U','n','k','n','o','w','n',' ',' ',' ',' '
+	'U','n','k','n','o','w','n',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' '
 #endif
 };
 


### PR DESCRIPTION
It looks like Arduino uses USBCore to assign vendor/board names to user programs that use LUFA. Here's a patch that (hopefully) adds the correct ones for the SparkFun devices covered in this board file.

There seemed to be a mismatch between the USB PID numbers in the boards.txt and bootloader definitions, though. I changed them all to be similar to the bootloader ones, but am not sure if that was the correct choice.

Thanks for providing your board support package! I based ours directly on it:
https://github.com/blinkiverse/Blinkiverse32u4_boards
