### PR TITLE
Fixed broken Arduino driver for Sparkfun Makey Makey.

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -79,5 +79,5 @@ minibench.build.mcu=atmega32u4
 minibench.build.f_cpu=16000000L
 minibench.build.vid=0x1B4F
 minibench.build.pid=0x2B75
-minibench.build.core=arduino
+minibench.build.core=arduino:arduino
 minibench.build.variant=promicro


### PR DESCRIPTION
This small change fixes issues with using the Makey Makey in the current stable version of the Arduino IDE (v.1.0.5). Without this change, Makey Makey code fails to compile on the current Arduino IDE.
