### PR TITLE
Compiler configuration does not work with on Mac OS X w/ v1.6.2 of IDE

### DIFF
--- a/sparkfun/avr/platform.txt
+++ b/sparkfun/avr/platform.txt
@@ -12,7 +12,7 @@ version=1.6.0
 # --------------------- 
 
 # Default "compiler.path" is correct, change only if you want to overidde the initial value
-compiler.path={runtime.ide.path}/hardware/tools/avr/bin/
+#compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
 compiler.c.flags=-c -g -Os -w -ffunction-sections -fdata-sections -MMD
 # -w flag added to avoid printing a wrong warning http://gcc.gnu.org/bugzilla/show_bug.cgi?id=59396


### PR DESCRIPTION
The `platform.txt` overrides the default compiler path to a sub-directory of the IDE. This doesn't work on Mac OS X where the tools can live in `~/Library/Arduino15/...`.

Trust the comment and things will work on Mac OS X.